### PR TITLE
共有定義を「同意不要」で定義すると、蓄積イベント通知が送信されない問題の修正 issue/#9

### DIFF
--- a/src/services/AccessControlManagerService.ts
+++ b/src/services/AccessControlManagerService.ts
@@ -52,6 +52,8 @@ export default class AccessControlManagerService {
             const { statusCode } = result.response;
             if (statusCode === ResponseCode.NO_CONTENT || statusCode === ResponseCode.BAD_REQUEST) {
                 throw new AppError(result.body.message, ResponseCode.BAD_REQUEST);
+            } else if (statusCode === ResponseCode.UNAUTHORIZED) {
+                throw new AppError(result.body.message, ResponseCode.UNAUTHORIZED);
             } else if (statusCode !== ResponseCode.OK) {
                 throw new AppError(Message.FAILED_CREATE_TOKEN, statusCode);
             }

--- a/src/tests/02-01.AccessControl.spec.ts
+++ b/src/tests/02-01.AccessControl.spec.ts
@@ -6,6 +6,8 @@ import * as supertest from 'supertest';
 import Application from '../index';
 import Common, { Url } from './Common';
 import { Session } from './Session';
+import { DateTimeFormatString } from '../common/Transform';
+import moment = require('moment');
 
 // 対象アプリケーションを取得
 const expressApp = Application.express.app;
@@ -30,6 +32,11 @@ describe('access-control API', () => {
         // サーバ停止
         await Application.stop();
     });
+
+    // 有効期限
+    const expirationDate = moment(new Date())
+        .add(parseInt('40'), 'minutes')
+        .format(DateTimeFormatString);
 
     /**
      * APIトークン取得開始
@@ -62,7 +69,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -107,7 +114,7 @@ describe('access-control API', () => {
                                 blockCode: 4444444,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -158,7 +165,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -209,7 +216,7 @@ describe('access-control API', () => {
                                 blockCode: 4444444,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event/%253Fns%253D%252Fabc',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -260,7 +267,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -301,7 +308,7 @@ describe('access-control API', () => {
                                 blockCode: 7777777,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -346,7 +353,7 @@ describe('access-control API', () => {
                                 blockCode: 4444444,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -377,7 +384,7 @@ describe('access-control API', () => {
                                 blockCode: 5555555,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -438,7 +445,7 @@ describe('access-control API', () => {
                             blockCode: 2222222,
                             apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                             apiMethod: 'GET',
-                            expirationDate: '2500-11-19T10:06:34.000+0900',
+                            expirationDate,
                             parameter: null
                         }
                     }
@@ -470,7 +477,7 @@ describe('access-control API', () => {
                                 blockCode: 2222222,
                                 apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: null
                             }
                         }
@@ -504,7 +511,7 @@ describe('access-control API', () => {
                                 blockCode: 2222222,
                                 apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: null
                             }
                         }
@@ -538,7 +545,7 @@ describe('access-control API', () => {
                                 blockCode: 'bbbbb',
                                 apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: null
                             }
                         }
@@ -572,7 +579,7 @@ describe('access-control API', () => {
                                 blockCode: 2222222,
                                 apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: null
                             }
                         }
@@ -767,7 +774,7 @@ describe('access-control API', () => {
                                 blockCode: 2222222,
                                 apiUrl: 'https://~~~/info-account-manage/{userId}/contract',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: null
                             }
                         }
@@ -844,7 +851,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -894,7 +901,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -945,7 +952,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -996,7 +1003,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -1046,7 +1053,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -1097,7 +1104,7 @@ describe('access-control API', () => {
                                 blockCode: 6666666,
                                 apiUrl: 'https://~~~/book-operate/share',
                                 apiMethod: 'GET',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -1141,7 +1148,7 @@ describe('access-control API', () => {
                                 blockCode: 4444444,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -1185,7 +1192,7 @@ describe('access-control API', () => {
                                 blockCode: 4444444,
                                 apiUrl: 'https://~~~/book-operate/store/{userId}/event',
                                 apiMethod: 'POST',
-                                expirationDate: '2500-11-19T10:06:34.000+0900',
+                                expirationDate,
                                 parameter: {
                                     dataType: [
                                         {
@@ -1245,6 +1252,85 @@ describe('access-control API', () => {
 
             // Expect status Bad Request
             expect(response.status).toBe(400);
+        });
+    });
+    describe('SNS通知バグ対応追加ケース', () => {
+        test('正常: api_access_permission.parameter にリクエストと同等の内容が保存されているかを確認', async () => {
+            const response = await supertest(expressApp)
+                .post(Url.accessControlURI)
+                .set({ 'Content-Type': 'application/json', accept: 'application/json' })
+                .set({ session: encodeURIComponent(JSON.stringify(Session.pxrRoot)) })
+                .send(JSON.stringify(
+                    [
+                        {
+                            caller: {
+                                blockCode: 3333333,
+                                apiUrl: 'https://~~~/book-operate/share/{userId}',
+                                apiMethod: 'POST',
+                                userId: 'xxx_yyy.app',
+                                apiCode: '0abdbf81-686c-423b-823a-ac0d889b0ae6',
+                                operator: {
+                                    type: 2,
+                                    app: {
+                                        _value: 1000099,
+                                        _ver: 1
+                                    },
+                                    loginId: 'app_member01'
+                                }
+                            },
+                            target: {
+                                blockCode: 6666666,
+                                apiUrl: 'https://~~~/book-operate/share',
+                                apiMethod: 'GET',
+                                expirationDate,
+                                parameter: JSON.stringify({
+                                    document: [
+                                        {
+                                            _value: 1000008,
+                                            _ver: 1
+                                        }
+                                    ],
+                                    event: [
+                                        {
+                                            _value: 1000008,
+                                            _ver: 1
+                                        }
+                                    ],
+                                    thing: [
+                                        {
+                                            _value: 1000008,
+                                            _ver: 1
+                                        }
+                                    ]
+                                })
+                            }
+                        }
+                    ]
+                ));
+
+            // Expect status Success Code
+            expect(response.status).toBe(200);
+            const record = await common.executeSqlString(`select * from  pxr_access_control.api_access_permission where token='${response.body[0].apiToken}'`);
+            expect(record[0].parameter).toBe(JSON.stringify({
+                document: [
+                    {
+                        _value: 1000008,
+                        _ver: 1
+                    }
+                ],
+                event: [
+                    {
+                        _value: 1000008,
+                        _ver: 1
+                    }
+                ],
+                thing: [
+                    {
+                        _value: 1000008,
+                        _ver: 1
+                    }
+                ]
+            }));
         });
     });
 });

--- a/src/tests/Common.ts
+++ b/src/tests/Common.ts
@@ -62,6 +62,6 @@ export default class Common {
      */
     public async executeSqlString (sql: string) {
         // DBを初期化
-        await (await connectDatabase()).query(sql);
+        return (await connectDatabase()).query(sql);
     }
 }

--- a/src/tests/StubServer.ts
+++ b/src/tests/StubServer.ts
@@ -74,21 +74,26 @@ export class AccessControlManageServer {
 export class AccessControlManageServerStore {
     app: express.Express;
     server: Server;
-    constructor (port: number) {
+    constructor (port: number, status?: number) {
         this.app = express();
-        this.app.use(bodyParser.json({ limit: '50mb' }) as express.RequestHandler);
+        this.app.use(bodyParser.json({ limit: '50mb' }));
         this.app.post('/access-control-manage/store', (req: express.Request, res: express.Response) => {
-            const obj = req.body.map((elem: any, index: number) => {
-                return {
-                    apiUrl: elem.target.apiUrl,
-                    apiMethod: elem.target.apiMethod,
-                    apiToken: 'd0af96799512cf7e4b9ebda5234a7cc8ea49d402d29191b5e9128e15a939917' + index,
-                    userId: elem.caller.userId,
-                    expirationDate: '2020-12-28T14:20:34.000+0900',
-                    blockCode: elem.target.blockCode || 1000109
-                };
-            });
-            res.status(200).json(obj);
+            if (!status) {
+                const obj = req.body.map((elem: any, index: number) => {
+                    return {
+                        apiUrl: elem.target.apiUrl,
+                        apiMethod: elem.target.apiMethod,
+                        apiToken: 'd0af96799512cf7e4b9ebda5234a7cc8ea49d402d29191b5e9128e15a939917' + index,
+                        userId: elem.caller.userId,
+                        expirationDate: '2020-12-28T14:20:34.000+0900',
+                        blockCode: elem.target.blockCode || 1000109
+                    };
+                });
+                res.status(200).json(obj);
+            } else if (status === 401) {
+                res.status(401).json({ message: '不可判定メッセージ' });
+            } 
+            
         });
         this.server = this.app.listen(port);
     }


### PR DESCRIPTION
## 修正内容

### アクセス制御サービス.APIトークン取得API
- POST access-control/token
- 利用ケース
- 修正内容
    - アクセス制御管理サービスのAPIトークン生成指示APIからエラーレスポンスが返却された際、それが不可判定によるエラーの場合は専用のエラーメッセージを送出するよう修正

- 考慮すべきUTバリエーション
    - アクセス制御管理サービスのAPIトークン生成指示APIのレスポンス
        - 正常
        - 400エラー
            - 蓄積/共有不可判定のエラー
            - それ以外の400エラー
        - 400以外のエラー
    - 既存のAPIトークンの共有・蓄積可データ種について、保存・取得ができているかについてのUTケース追加（下記の2API）


### アクセス制御サービス.APIアクセス許可生成API
- POST /access-control
- 利用ケース
    - アクセス制御管理から呼び出され、APIトークンを発行する
- UTバリエーション
    - リクエスト.target.parameter の内容
        - 生成したapi_access_permissionレコードについてアサート追加
        - api_access_permission.parameter にリクエストと同等の内容が保存されているかをチェックする

### アクセス制御サービス.APIアクセス許可照合API
- POST /access-control/collate
- 利用ケース
    - リバースプロキシから呼び出され、APIトークンの照合を行う
- UTバリエーション
    - DB の api_access_permission の内容
        - レスポンス.parameterについてアサート追加
        - api_access_permission.parameter の内容がレスポンスに反映されているかをチェックする

fixes #9 

## UnitTest

### UT環境
```
$ node --version
v18.16.1
```
```
$ psql -V
psql (PostgreSQL) 15.6
```

### UT実行結果
```
npm run test:unit

$ npm run test:unit

> access-control-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/01-01.Token.spec.ts (15.367 s)
PASS src/tests/02-01.AccessControl.spec.ts
PASS src/tests/03-01.Collate.spec.ts
PASS src/tests/01-29.Token.OperatorError1.spec.ts
PASS src/tests/03-02.CollateOk.spec.ts
PASS src/tests/00-00.Validation.spec.ts
PASS src/tests/01-13.Token.AccessNomal2.spec.ts
PASS src/tests/01-28.Token.BinaryUpload.spec.ts
PASS src/tests/01-17.Token.dbSelectDateError.spec.ts
PASS src/tests/01-16.Token.dbSelectDateOk.spec.ts
PASS src/tests/01-14.Token.Normal2.spec.ts
PASS src/tests/03-08.Collate.NoMacthError.spec.ts
PASS src/tests/03-09.Collate.Macth.spec.ts
PASS src/tests/01-19.Token.ApiTokenReceiveCheckOK.spec.ts
PASS src/tests/01-12.Token.AccessNomal1.spec.ts
PASS src/tests/01-15.Token.Normal3.spec.ts
PASS src/tests/01-10.Token.Abnormal3.spec.ts
-----------------------------------|---------|----------|---------|---------|-------------------
File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------|---------|----------|---------|---------|-------------------
All files                          |   99.71 |     96.8 |   98.41 |   99.84 |                
 domains                           |     100 |      100 |     100 |     100 |                
  ApiAccessPermissionDomain.ts     |     100 |      100 |     100 |     100 |                
  ApiTokenDomain.ts                |     100 |      100 |     100 |     100 |                
 repositories/postgres             |     100 |      100 |     100 |     100 |                
  ApiAccessPermissionEntity.ts     |     100 |      100 |     100 |     100 |                
  ApiAccessPermissionRepository.ts |     100 |      100 |     100 |     100 |                
  ApiTokenEntity.ts                |     100 |      100 |     100 |     100 |                
  ApiTokenRepository.ts            |     100 |      100 |     100 |     100 |                
  CallerRoleEntity.ts              |     100 |      100 |     100 |     100 |                
 resources                         |     100 |      100 |     100 |     100 |                
  AccessControlController.ts       |     100 |      100 |     100 |     100 |                
  CollateController.ts             |     100 |      100 |     100 |     100 |                
  TokenController.ts               |     100 |      100 |     100 |     100 |                
 resources/dto                     |   98.96 |      100 |   95.83 |     100 |                
  PostAccessControlReqDto.ts       |   97.61 |      100 |   91.66 |     100 |                
  PostAccessControlResDto.ts       |     100 |      100 |     100 |     100 |                
  PostCollateReqDto.ts             |     100 |      100 |     100 |     100 |                
  PostTokenReqDto.ts               |     100 |      100 |     100 |     100 |                
  PostTokenResDto.ts               |     100 |      100 |     100 |     100 |                
 resources/validator               |     100 |      100 |     100 |     100 |                
  AccessControlPostValidator.ts    |     100 |      100 |     100 |     100 |                
  CollatePostValidator.ts          |     100 |      100 |     100 |     100 |                
  TokenPostValidator.ts            |     100 |      100 |     100 |     100 |                
 services                          |   99.61 |    95.65 |     100 |    99.6 |                
  AccessControlManagerService.ts   |     100 |      100 |     100 |     100 |                
  AccessControlService.ts          |     100 |    66.66 |     100 |     100 | 80-81          
  CollateService.ts                |     100 |      100 |     100 |     100 |                
  TokenService.ts                  |   99.35 |       98 |     100 |   99.33 | 135            
 services/dto                      |     100 |      100 |     100 |     100 |                
  AccessControlManageResult.ts     |     100 |      100 |     100 |     100 |                
-----------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 17 passed, 17 total
Tests:       119 passed, 119 total
Snapshots:   0 total
Time:        55.528 s
Ran all test suites.

Jest has detected the following 4 open handles potentially keeping Jest from exiting:

  ●  TCPWRAP

      at Connection.connect (node_modules/pg/lib/connection.js:44:17)
      at Client._connect (node_modules/pg/lib/client.js:113:11)
      at Client.connect (node_modules/pg/lib/client.js:162:12)
      at BoundPool.newClient (node_modules/pg-pool/index.js:237:12)
      at BoundPool.connect (node_modules/pg-pool/index.js:212:10)
      at src/driver/postgres/PostgresDriver.ts:1507:18
      at PostgresDriver.createPool (src/driver/postgres/PostgresDriver.ts:1506:16)
      at PostgresDriver.connect (src/driver/postgres/PostgresDriver.ts:346:38)
      at DataSource.initialize (src/data-source/DataSource.ts:249:27)
      at DataSource.connect (src/data-source/DataSource.ts:293:21)
      at createConnection (src/globals.ts:100:51)
      at src/common/Connection.ts:31:44
      at src/common/Connection.ts:8:71
      at Object.<anonymous>.__awaiter (src/common/Connection.ts:4:12)
      at connectDatabase (src/common/Connection.ts:37:12)
      at src/index.ts:10:30
      at src/index.ts:8:71
      at Object.<anonymous>.__awaiter (src/index.ts:4:12)
      at src/index.ts:8:13
      at Object.<anonymous> (src/index.ts:15:3)
      at Object.<anonymous> (src/tests/01-19.Token.ApiTokenReceiveCheckOK.spec.ts:6:1)


  ●  TCPWRAP

      at Connection.connect (node_modules/pg/lib/connection.js:44:17)
      at Client._connect (node_modules/pg/lib/client.js:113:11)
      at Client.connect (node_modules/pg/lib/client.js:162:12)
      at BoundPool.newClient (node_modules/pg-pool/index.js:237:12)
      at BoundPool.connect (node_modules/pg-pool/index.js:212:10)
      at src/driver/postgres/PostgresDriver.ts:1507:18
      at PostgresDriver.createPool (src/driver/postgres/PostgresDriver.ts:1506:16)
      at PostgresDriver.connect (src/driver/postgres/PostgresDriver.ts:346:38)
      at DataSource.initialize (src/data-source/DataSource.ts:249:27)
      at DataSource.connect (src/data-source/DataSource.ts:293:21)
      at createConnection (src/globals.ts:100:51)
      at src/common/Connection.ts:31:44
      at src/common/Connection.ts:8:71
      at Object.<anonymous>.__awaiter (src/common/Connection.ts:4:12)
      at connectDatabase (src/common/Connection.ts:37:12)
      at src/index.ts:10:30
      at src/index.ts:8:71
      at Object.<anonymous>.__awaiter (src/index.ts:4:12)
      at src/index.ts:8:13
      at Object.<anonymous> (src/index.ts:15:3)
      at Object.<anonymous> (src/tests/01-12.Token.AccessNomal1.spec.ts:6:1)


  ●  TCPWRAP

      at Connection.connect (node_modules/pg/lib/connection.js:44:17)
      at Client._connect (node_modules/pg/lib/client.js:113:11)
      at Client.connect (node_modules/pg/lib/client.js:162:12)
      at BoundPool.newClient (node_modules/pg-pool/index.js:237:12)
      at BoundPool.connect (node_modules/pg-pool/index.js:212:10)
      at src/driver/postgres/PostgresDriver.ts:1507:18
      at PostgresDriver.createPool (src/driver/postgres/PostgresDriver.ts:1506:16)
      at PostgresDriver.connect (src/driver/postgres/PostgresDriver.ts:346:38)
      at DataSource.initialize (src/data-source/DataSource.ts:249:27)
      at DataSource.connect (src/data-source/DataSource.ts:293:21)
      at createConnection (src/globals.ts:100:51)
      at src/common/Connection.ts:31:44
      at src/common/Connection.ts:8:71
      at Object.<anonymous>.__awaiter (src/common/Connection.ts:4:12)
      at connectDatabase (src/common/Connection.ts:37:12)
      at src/index.ts:10:30
      at src/index.ts:8:71
      at Object.<anonymous>.__awaiter (src/index.ts:4:12)
      at src/index.ts:8:13
      at Object.<anonymous> (src/index.ts:15:3)
      at Object.<anonymous> (src/tests/01-15.Token.Normal3.spec.ts:6:1)


  ●  TCPWRAP

      at Connection.connect (node_modules/pg/lib/connection.js:44:17)
      at Client._connect (node_modules/pg/lib/client.js:113:11)
      at Client.connect (node_modules/pg/lib/client.js:162:12)
      at BoundPool.newClient (node_modules/pg-pool/index.js:237:12)
      at BoundPool.connect (node_modules/pg-pool/index.js:212:10)
      at src/driver/postgres/PostgresDriver.ts:1507:18
      at PostgresDriver.createPool (src/driver/postgres/PostgresDriver.ts:1506:16)
      at PostgresDriver.connect (src/driver/postgres/PostgresDriver.ts:346:38)
      at DataSource.initialize (src/data-source/DataSource.ts:249:27)
      at DataSource.connect (src/data-source/DataSource.ts:293:21)
      at createConnection (src/globals.ts:100:51)
      at src/common/Connection.ts:31:44
      at src/common/Connection.ts:8:71
      at Object.<anonymous>.__awaiter (src/common/Connection.ts:4:12)
      at connectDatabase (src/common/Connection.ts:37:12)
      at src/index.ts:10:30
      at src/index.ts:8:71
      at Object.<anonymous>.__awaiter (src/index.ts:4:12)
      at src/index.ts:8:13
      at Object.<anonymous> (src/index.ts:15:3)
      at Object.<anonymous> (src/tests/01-10.Token.Abnormal3.spec.ts:6:1)
```