### PR TITLE
継続的共有／一時的共有のレスポンスが配列にならない場合がある問題の修正 issue/#12

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -19,3 +19,6 @@ operatorService:
     session: http://localhost:3000/operator/session/
 
 timezone: Asia/Tokyo
+
+# APIトークン有効期限チェック時に使用するバッファ時間（秒）
+bufferTime: 10


### PR DESCRIPTION
## 修正内容
* トークン取得APIにおいて、レスポンス返却前に呼出元URL、呼出元Method、呼出先blockCodeが全て同一の要素を除去するフィルタ処理を追加
* DBから取得したトークンをレスポンスに加える際、ResDto型のオブジェクトを新規作成して配列に追加するよう変更
　※既存処理では参照を配列に追加しながら、参照元を上書きする処理になっていたため修正（= ークンが複数取得できた場合、レスポンス配列の要素が全て最後の要素の内容になる状態になっていた））
* config/default.ymlに、bufferTime：APIトークン有効期限チェック時に使用するバッファ時間（秒）の設定を追加。
  * ブロックごとにAPIトークン有効期限がズレないようにする
  * 有効期限チェック時にはバッファを設ける（イメージ：有効期限の日時＜Now＋バッファ時間）
    * ※バッファ時間は10s程度が妥当だが、10がマジックナンバーにならないように定義する

fixes #12

## UT環境
~~~
$ node --version
v18.16.0

$ PGPASSWORD="postgres" psql -U postgres -h localhost -p 5432 -c "SELECT version();"
                          version
------------------------------------------------------------
 PostgreSQL 15.7, compiled by Visual C++ build 1939, 64-bit
(1 行)
~~~

## UT実行結果
~~~
$ npm run test:unit

> access-control-service@1.0.0 test:unit
> jest --coverage --forceExit --detectOpenHandles --runInBand --config=jest.unit.config.js

PASS src/tests/01-01.Token.spec.ts (12.089 s)
PASS src/tests/01-14.Token.Normal2.spec.ts
PASS src/tests/03-01.Collate.spec.ts
PASS src/tests/03-02.CollateOk.spec.ts
PASS src/tests/01-28.Token.BinaryUpload.spec.ts
PASS src/tests/01-13.Token.AccessNomal2.spec.ts
PASS src/tests/01-29.Token.OperatorError1.spec.ts
PASS src/tests/03-08.Collate.NoMacthError.spec.ts
PASS src/tests/02-01.AccessControl.spec.ts
PASS src/tests/01-10.Token.Abnormal3.spec.ts
PASS src/tests/03-09.Collate.Macth.spec.ts
PASS src/tests/01-16.Token.dbSelectDateOk.spec.ts
PASS src/tests/01-19.Token.ApiTokenReceiveCheckOK.spec.ts
PASS src/tests/01-15.Token.Normal3.spec.ts
PASS src/tests/01-12.Token.AccessNomal1.spec.ts
PASS src/tests/01-17.Token.dbSelectDateError.spec.ts
PASS src/tests/00-00.Validation.spec.ts
-----------------------------------|---------|----------|---------|---------|-------------------
File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------|---------|----------|---------|---------|-------------------
All files                          |   99.71 |    96.93 |   98.41 |   99.84 |   
 domains                           |     100 |      100 |     100 |     100 |   
  ApiAccessPermissionDomain.ts     |     100 |      100 |     100 |     100 |   
  ApiTokenDomain.ts                |     100 |      100 |     100 |     100 |   
 repositories/postgres             |     100 |      100 |     100 |     100 |   
  ApiAccessPermissionEntity.ts     |     100 |      100 |     100 |     100 |   
  ApiAccessPermissionRepository.ts |     100 |      100 |     100 |     100 |   
  ApiTokenEntity.ts                |     100 |      100 |     100 |     100 |   
  ApiTokenRepository.ts            |     100 |      100 |     100 |     100 |   
  CallerRoleEntity.ts              |     100 |      100 |     100 |     100 |   
 resources                         |     100 |      100 |     100 |     100 |   
  AccessControlController.ts       |     100 |      100 |     100 |     100 |   
  CollateController.ts             |     100 |      100 |     100 |     100 |   
  TokenController.ts               |     100 |      100 |     100 |     100 |   
 resources/dto                     |   98.96 |      100 |   95.83 |     100 |   
  PostAccessControlReqDto.ts       |   97.61 |      100 |   91.66 |     100 |   
  PostAccessControlResDto.ts       |     100 |      100 |     100 |     100 |   
  PostCollateReqDto.ts             |     100 |      100 |     100 |     100 |   
  PostTokenReqDto.ts               |     100 |      100 |     100 |     100 |   
  PostTokenResDto.ts               |     100 |      100 |     100 |     100 |   
 resources/validator               |     100 |      100 |     100 |     100 |   
  AccessControlPostValidator.ts    |     100 |      100 |     100 |     100 |   
  CollatePostValidator.ts          |     100 |      100 |     100 |     100 |   
  TokenPostValidator.ts            |     100 |      100 |     100 |     100 |   
 services                          |    99.6 |    95.89 |     100 |   99.59 |   
  AccessControlManagerService.ts   |     100 |      100 |     100 |     100 |   
  AccessControlService.ts          |     100 |    66.66 |     100 |     100 | 80-81
  CollateService.ts                |     100 |      100 |     100 |     100 |   
  TokenService.ts                  |   99.33 |    98.14 |     100 |   99.31 | 136
 services/dto                      |     100 |      100 |     100 |     100 |   
  AccessControlManageResult.ts     |     100 |      100 |     100 |     100 |   
-----------------------------------|---------|----------|---------|---------|-------------------

Test Suites: 17 passed, 17 total
Tests:       121 passed, 121 total
Snapshots:   0 total
Time:        55.009 s, estimated 72 s
Ran all test suites.
~~~